### PR TITLE
Add link to rust driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ adding it to this section of the documentation. We also collect maker guides at
 
 [instructables.com/Facial-Recognition-Using-the-Person-Sensor-and-Pic/](https://www.instructables.com/Facial-Recognition-Using-the-Person-Sensor-and-Pic/)
 
+#### Rust embedded-hal driver
+
+[github.com/riley-williams/person-sensor](https://github.com/riley-williams/person-sensor)
+
 ## Privacy
 This module includes an image sensor, and we want to make sure that this doesn’t
 pose a threat to any of our users’ privacy. We’ve designed the module so that it


### PR DESCRIPTION
This adds a link to a Rust driver I created. It only depends on the embedded-hal-async interfaces, meaning it's portable to any MCU. In this sense it doesn't exactly fit with the other examples that are MCU specific, but I don't see a better place.